### PR TITLE
Try to fix fuzz.c for named

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "log.h": "c"
+    }
+}

--- a/doc/misc/options
+++ b/doc/misc/options
@@ -145,7 +145,7 @@ options {
 	fstrm-set-output-queue-model ( mpsc | spsc ); // not configured
 	fstrm-set-output-queue-size <integer>; // not configured
 	fstrm-set-reopen-interval <duration>; // not configured
-	geoip-directory ( <quoted_string> | none );
+	geoip-directory ( <quoted_string> | none ); // not configured
 	heartbeat-interval <integer>;
 	hostname ( <quoted_string> | none );
 	http-listener-clients <integer>;
@@ -162,7 +162,7 @@ options {
 	lame-ttl <duration>;
 	listen-on [ port <integer> ] [ tls <string> ] [ http <string> ] { <address_match_element>; ... }; // may occur multiple times
 	listen-on-v6 [ port <integer> ] [ tls <string> ] [ http <string> ] { <address_match_element>; ... }; // may occur multiple times
-	lmdb-mapsize <sizeval>;
+	lmdb-mapsize <sizeval>; // not configured
 	lock-file ( <quoted_string> | none );
 	managed-keys-directory <quoted_string>;
 	masterfile-format ( raw | text );
@@ -443,7 +443,7 @@ view <string> [ <class> ] {
 	}; // may occur multiple times
 	key-directory <quoted_string>;
 	lame-ttl <duration>;
-	lmdb-mapsize <sizeval>;
+	lmdb-mapsize <sizeval>; // not configured
 	managed-keys { <string> ( static-key | initial-key | static-ds | initial-ds ) <integer> <integer> <integer> <quoted_string>; ... }; // may occur multiple times, deprecated
 	masterfile-format ( raw | text );
 	masterfile-style ( full | relative );

--- a/lib/ns/client.c
+++ b/lib/ns/client.c
@@ -2021,6 +2021,9 @@ ns_client_request(isc_nmhandle_t *handle, isc_result_t eresult,
 	result = client->manager->sctx->matchingview(
 		&netaddr, &client->destaddr, client->message, env, &sigresult,
 		&client->view);
+	if(!client->manager->sctx->fuzznotify) {
+		client->manager->sctx->fuzznotify();
+	}
 	if (result != ISC_R_SUCCESS) {
 		char classname[DNS_RDATACLASS_FORMATSIZE];
 

--- a/scripts/AFL.sh
+++ b/scripts/AFL.sh
@@ -1,0 +1,36 @@
+set -e
+AFL=/path/to/afl
+git clone https://github.com/jingtianer/bind9_namedfuzz.git bind9
+SUBJECT=$PWD/bind9
+
+export AFL_PERSISTENT=1
+export LD_LIBRARY_PATH=$SUBJECT/lib/isc/.libs:$SUBJECT/lib/dns/.libs:$SUBJECT/lib/isccc/.libs:$SUBJECT/lib/isccfg/.libs
+
+export CC=$AFLFAST/afl-clang-fast
+export CXX=$AFLFAST/afl-clang-fast++
+
+export CFLAGS="-D ENABLE_AFL"
+export CXXFLAGS="-D ENABLE_AFL"
+
+pushd $SUBJECT
+	autoreconf -fi
+	./configure  --enable-fuzzing=afl
+	sudo make -j
+	sudo make install
+popd
+
+if [ ! -d workdir ]; then
+    mkdir workdir
+fi
+tee named.conf <<-'EOF'
+options {
+    directory    "$PWD/workdir";
+    allow-query     { any; };
+    listen-on port 1053 { any; };
+};
+EOF
+pattern="s/\$PWD/$(echo `pwd` | sed "s/\//\\\\\//g")/g"
+sed -i $pattern named.conf 
+cat named.conf
+
+$AFLFAST/afl-fuzz -t 50000 -m none -i in -o out -- $SUBJECT/bin/named/.libs/named -A client:127.0.0.1:1053 -g -c named.conf

--- a/scripts/AFLFast.sh
+++ b/scripts/AFLFast.sh
@@ -1,0 +1,36 @@
+set -e
+AFLFAST=/path/to/aflfast
+git clone https://github.com/jingtianer/bind9_namedfuzz.git bind9
+SUBJECT=$PWD/bind9
+
+export AFL_PERSISTENT=1
+export LD_LIBRARY_PATH=$SUBJECT/lib/isc/.libs:$SUBJECT/lib/dns/.libs:$SUBJECT/lib/isccc/.libs:$SUBJECT/lib/isccfg/.libs
+
+export CC=$AFLFAST/afl-clang-fast
+export CXX=$AFLFAST/afl-clang-fast++
+
+export CFLAGS="-D ENABLE_AFL"
+export CXXFLAGS="-D ENABLE_AFL"
+
+pushd $SUBJECT
+	autoreconf -fi
+	./configure  --enable-fuzzing=afl
+	sudo make -j
+	sudo make install
+popd
+
+if [ ! -d workdir ]; then
+    mkdir workdir
+fi
+tee named.conf <<-'EOF'
+options {
+    directory    "$PWD/workdir";
+    allow-query     { any; };
+    listen-on port 1053 { any; };
+};
+EOF
+pattern="s/\$PWD/$(echo `pwd` | sed "s/\//\\\\\//g")/g"
+sed -i $pattern named.conf 
+cat named.conf
+
+$AFLFAST/afl-fuzz -t 50000 -m none -i in -o out -- $SUBJECT/bin/named/.libs/named -A client:127.0.0.1:1053 -g -c named.conf


### PR DESCRIPTION
I just fixed the the fuzz.c for named. Two scripts under `bind9/scripts` is offered to fuzz `named` by `afl` and `aflfast`, with argument `-A client:127.0.0.1:1053`.